### PR TITLE
Fix a bug where the FinInstnId tag would be self-closing, if no bic was

### DIFF
--- a/sepaxml/debit.py
+++ b/sepaxml/debit.py
@@ -342,7 +342,7 @@ class SepaDD(SepaPaymentInitn):
         if 'BIC_DbtrAgt_Node' in TX_nodes and TX_nodes['BIC_DbtrAgt_Node'].text is not None:
             TX_nodes['FinInstnId_DbtrAgt_Node'].append(
                 TX_nodes['BIC_DbtrAgt_Node'])
-        elif self.schema != 'pain.008.001.02':
+        else:
             TX_nodes['Othr_DbtrAgt_Node'].append(
                 TX_nodes['Id_DbtrAgt_Node'])
             TX_nodes['FinInstnId_DbtrAgt_Node'].append(
@@ -383,7 +383,7 @@ class SepaDD(SepaPaymentInitn):
         if 'BIC_DbtrAgt_Node' in TX_nodes and TX_nodes['BIC_DbtrAgt_Node'].text is not None:
             TX_nodes['FinInstnId_DbtrAgt_Node'].append(
                 TX_nodes['BIC_DbtrAgt_Node'])
-        elif self.schema != 'pain.008.001.02':
+        else:
             TX_nodes['Othr_DbtrAgt_Node'].append(
                 TX_nodes['Id_DbtrAgt_Node'])
             TX_nodes['FinInstnId_DbtrAgt_Node'].append(

--- a/tests/debit/test_no_bic.py
+++ b/tests/debit/test_no_bic.py
@@ -92,7 +92,11 @@ SAMPLE_RESULT = b"""
           </MndtRltdInf>
         </DrctDbtTx>
         <DbtrAgt>
-          <FinInstnId/>
+          <FinInstnId>
+            <Othr>
+              <Id>NOTPROVIDED</Id>
+            </Othr>
+          </FinInstnId>
         </DbtrAgt>
         <Dbtr>
           <Nm>Test von Testenstein</Nm>
@@ -161,7 +165,11 @@ SAMPLE_RESULT = b"""
           </MndtRltdInf>
         </DrctDbtTx>
         <DbtrAgt>
-          <FinInstnId/>
+          <FinInstnId>
+            <Othr>
+              <Id>NOTPROVIDED</Id>
+            </Othr>
+          </FinInstnId>
         </DbtrAgt>
         <Dbtr>
           <Nm>Test du Test</Nm>


### PR DESCRIPTION
This fix solves an issue by populating the FinInstnId tag, as defined by the pain.008.001.02 standard, whenever a debit payment is added, that has no BIC set